### PR TITLE
Update workflow trigger with pw projects

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,18 @@ on:
     branches: [main, master]
 
   workflow_dispatch:
+    inputs:
+      project:
+        description: 'Playwright project to run'
+        required: true
+        type: choice
+        options:
+          - api
+          - e2e:chromium
+          - e2e:firefox
+          - e2e:webkit
+          - all
+        default: 'all'
 
 permissions:
   contents: read
@@ -65,7 +77,12 @@ jobs:
         run: npm run prepare
 
       - name: Run Playwright tests
-        run: npm run test
+        run: |
+          if [ "${{ inputs.project }}" = "all" ]; then
+            npm run test
+          else
+            npm run test -- --project="${{ inputs.project }}"
+          fi
 
       - name: Upload artifact
         if: always()

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Before running tests, the CI pipeline performs comprehensive static code analysi
 
 - **Pull Request**: Automatically triggered on PRs to `main` branch
 - **Manual Dispatch**: Can be manually triggered from [GitHub Actions](https://github.com/Ostap-Z/ts-pw-interview-task/actions)
+  - **Project Selection**: Choose from available Playwright projects:
+    - `api`: Run API tests
+    - `e2e:chromium`: Run E2E tests on Chrome
+    - `e2e:firefox`: Run E2E tests on Firefox
+    - `e2e:webkit`: Run E2E tests on Safari
+    - `all`: Run all test projects
 
 ### Test Report
 


### PR DESCRIPTION
## Summary by Sourcery

Enhance the GitHub Actions workflow to support manual selection of specific Playwright test projects, and update documentation to reflect these changes.

CI:
- Add input options for Playwright project selection in the workflow_dispatch trigger, allowing manual selection of specific test projects to run.

Documentation:
- Update README to include instructions for selecting Playwright projects when manually triggering workflows.