### PR TITLE
Update gh workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -51,9 +52,13 @@ jobs:
   playwright_tests:
     needs: static_checks
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.49.0
+    timeout-minutes: 10
     strategy:
       fail-fast: false
     env:
+      HOME: /root
       API_BASE_URL: https://jsonplaceholder.typicode.com
       UI_BASE_URL: https://example.com
 
@@ -69,16 +74,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
 
       - name: Install Playwright Browsers
-        run: npm run prepare
+        run: npx playwright install --with-deps
 
       - name: Run Playwright tests
         run: |
-          if [ "${{ inputs.project }}" = "all" ]; then
+          if [ "${{ inputs.project || 'all' }}" = "all" ]; then
             npm run test
           else
             npm run test -- --project="${{ inputs.project }}"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ After each workflow run:
 
 1. Clone the repository
 2. Run `npm install`
-3. Run `npm run prepare` to install Playwright browsers
+3. Run `npx playwright install --with-deps` to install Playwright browsers
 4. Copy `.env.example` to `.env` and update the values:
 
    ```bash

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "node": "20.18.0"
   },
   "scripts": {
-    "prepare": "playwright install --with-deps",
     "test": "playwright test",
     "test:e2e": "playwright test tests/e2e/",
     "test:api": "playwright test --project=api",


### PR DESCRIPTION
## Summary by Sourcery

Update the GitHub Actions workflow to cache npm dependencies and use a Docker container for Playwright tests, removing the need for a separate Playwright installation step.

CI:
- Add npm cache to Node.js setup in GitHub Actions workflow to improve build efficiency.
- Use a Docker container with a specific Playwright image for running tests, ensuring a consistent environment.