### PR TITLE
Add pw step to reporter

### DIFF
--- a/src/api/controllers/posts.controller.ts
+++ b/src/api/controllers/posts.controller.ts
@@ -1,12 +1,15 @@
 import type { HttpResponse } from "../types/http.response";
 import type { Post } from "../models/post.model";
 import BaseController from "./base.controller";
+import { step } from "../../reporter/step";
 
 class PostsController extends BaseController {
+  @step()
   public async create(post: Post): Promise<HttpResponse> {
     return this.client.post(`${this.url}posts`, post);
   }
 
+  @step()
   public async getById(id: number): Promise<HttpResponse> {
     return this.client.get(`${this.url}posts/${id}`);
   }

--- a/src/pages/base.page.ts
+++ b/src/pages/base.page.ts
@@ -1,4 +1,5 @@
 import { expect, type Page } from "@playwright/test";
+import { step } from "../reporter/step";
 
 abstract class BasePage {
   public abstract readonly url: string;
@@ -10,6 +11,7 @@ abstract class BasePage {
 
   public constructor(protected readonly page: Page) {}
 
+  @step()
   public async open(
     url?: string,
     options?: { timeout?: number; message?: string }
@@ -18,6 +20,7 @@ abstract class BasePage {
     await this.expectLoaded(options);
   }
 
+  @step()
   public async expectHasTitle(title: string): Promise<void> {
     await expect(this.page).toHaveTitle(title);
   }

--- a/src/pages/example.page.ts
+++ b/src/pages/example.page.ts
@@ -1,15 +1,17 @@
 import { Locator, expect } from "@playwright/test";
 import BasePage from "./base.page";
+import { step } from "../reporter/step";
 
 class ExamplePage extends BasePage {
-  public override readonly url = "https://example.com";
+  public override readonly url = "/";
   private readonly heading: Locator = this.page.locator("h1");
 
+  @step()
   public override async expectLoaded(options?: {
     message?: string;
     timeout?: number;
   }): Promise<void> {
-    const expectMessage = options?.message ?? "Example page is not opened";
+    const expectMessage = options?.message ?? "Example page should be opened";
     const expectTimeout = options?.timeout ?? 10_000;
 
     await expect(this.heading, expectMessage).toBeVisible({

--- a/src/reporter/step.ts
+++ b/src/reporter/step.ts
@@ -1,0 +1,41 @@
+import { test } from "@playwright/test";
+
+/**
+ * Decorator that wraps a function with a Playwright test step.
+ * Used for reporting purposes.
+ *
+ * @example
+ ```typescript
+  import { step } from './step_decorator';
+
+  class MyTestClass {
+      @step('optional step name')
+      async myTestFunction() {
+          // Test code goes here
+      }
+  }
+ ```
+ */
+export function step<This, Args extends unknown[], Return>(message?: string) {
+  return function actualDecorator(
+    target: (this: This, ...args: Args) => Promise<Return>,
+    context: ClassMethodDecoratorContext<
+      This,
+      (this: This, ...args: Args) => Promise<Return>
+    >
+  ) {
+    function replacementMethod(this: This, ...args: Args) {
+      const stepName =
+        message ??
+        `${(this as { constructor: { name: string } }).constructor.name}.${
+          context.name as string
+        }`;
+
+      return test.step(stepName, async () => target.call(this, ...args), {
+        box: true,
+      });
+    }
+
+    return replacementMethod;
+  };
+}


### PR DESCRIPTION
## Summary by Sourcery

Add a Playwright test step decorator for reporting purposes.

New Features:
- Introduce a `@step` decorator to wrap test functions and methods within a Playwright test step for enhanced reporting.

Tests:
- Update tests to utilize the new `@step` decorator.