### PR TITLE
Add pw metadata to reporter

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,10 @@
-import { defineConfig, devices } from '@playwright/test';
-import dotenv from 'dotenv';
+import { defineConfig, devices } from "@playwright/test";
+import dotenv from "dotenv";
+import { gitStatus } from "./src/reporter/metadata";
 
 dotenv.config();
+
+const isMainWorker = !process.env.TEST_WORKER_INDEX;
 
 export default defineConfig({
   testDir: "./tests",
@@ -12,6 +15,7 @@ export default defineConfig({
     ? Math.max(1, Math.floor(parseInt(process.env.CORES || "2", 10) / 2))
     : undefined,
   reporter: [["html", { outputFolder: "playwright-report", open: "never" }]],
+  metadata: isMainWorker ? gitStatus() : undefined,
   use: {
     trace: "retain-on-failure",
   },

--- a/src/reporter/metadata.ts
+++ b/src/reporter/metadata.ts
@@ -1,0 +1,48 @@
+import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+
+const GIT_OPERATIONS_TIMEOUT_MS = 1500;
+
+interface Metadata {
+  'revision.id': string;
+  'revision.author': string;
+  'revision.email': string;
+  'revision.subject': string;
+  'revision.timestamp': number;
+}
+
+function gitStatus(
+  directory: string = process.cwd(),
+  options: {
+    timeout?: number;
+  } = { timeout: GIT_OPERATIONS_TIMEOUT_MS },
+): Metadata | undefined {
+  const separator = `:${randomUUID().slice(0, 4)}:`;
+  const { status, stdout } = spawnSync(
+    'git',
+    [
+      'show',
+      '-s',
+      `--format=%H${separator}%s${separator}%an${separator}%ae${separator}%ct`,
+      'HEAD',
+    ],
+    { stdio: 'pipe', cwd: directory, timeout: options?.timeout },
+  );
+  if (status) {
+    return;
+  }
+  const showOutput = stdout.toString().trim();
+  const [id, subject, author, email, rawTimestamp] = showOutput.split(separator);
+  let timestamp: number = Number.parseInt(rawTimestamp, 10);
+  timestamp = Number.isInteger(timestamp) ? timestamp * 1000 : 0;
+
+  return {
+    'revision.id': id,
+    'revision.author': author,
+    'revision.email': email,
+    'revision.subject': subject,
+    'revision.timestamp': timestamp,
+  };
+}
+
+export { gitStatus };


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Include git revision ID, author, email, subject, and timestamp in the Playwright HTML report.